### PR TITLE
Fix incorrect usage of fmt.Fprintf()

### DIFF
--- a/cmd/nerdctl/container_list.go
+++ b/cmd/nerdctl/container_list.go
@@ -194,7 +194,7 @@ func formatAndPrintContainerInfo(containers []container.ListItem, options Format
 			if err := tmpl.Execute(&b, c); err != nil {
 				return err
 			}
-			if _, err := fmt.Fprintf(w, b.String()+"\n"); err != nil {
+			if _, err := fmt.Fprintln(w, b.String()); err != nil {
 				return err
 			}
 		} else if options.Quiet {

--- a/cmd/nerdctl/image_history.go
+++ b/cmd/nerdctl/image_history.go
@@ -219,7 +219,7 @@ func (x *historyPrinter) printHistory(p historyPrintable) error {
 		if err := x.tmpl.Execute(&b, p); err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(x.w, b.String()+"\n"); err != nil {
+		if _, err := fmt.Fprintln(x.w, b.String()); err != nil {
 			return err
 		}
 	} else if x.quiet {

--- a/cmd/nerdctl/version.go
+++ b/cmd/nerdctl/version.go
@@ -72,7 +72,7 @@ func versionAction(cmd *cobra.Command, args []string) error {
 		if err := tmpl.Execute(&b, v); err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(w, b.String()+"\n"); err != nil {
+		if _, err := fmt.Fprintln(w, b.String()); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/cmd/apparmor/list_linux.go
+++ b/pkg/cmd/apparmor/list_linux.go
@@ -63,7 +63,7 @@ func List(options types.ApparmorListOptions) error {
 			if err := tmpl.Execute(&b, f); err != nil {
 				return err
 			}
-			if _, err = fmt.Fprintf(w, b.String()+"\n"); err != nil {
+			if _, err = fmt.Fprintln(w, b.String()); err != nil {
 				return err
 			}
 		} else if quiet {

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -264,7 +264,7 @@ func (x *imagePrinter) printImageSinglePlatform(ctx context.Context, img images.
 		if err := x.tmpl.Execute(&b, p); err != nil {
 			return err
 		}
-		if _, err = fmt.Fprintf(x.w, b.String()+"\n"); err != nil {
+		if _, err = fmt.Fprintln(x.w, b.String()); err != nil {
 			return err
 		}
 	} else if x.quiet {

--- a/pkg/cmd/network/list.go
+++ b/pkg/cmd/network/list.go
@@ -105,7 +105,7 @@ func List(ctx context.Context, options types.NetworkListOptions) error {
 			if err := tmpl.Execute(&b, p); err != nil {
 				return err
 			}
-			if _, err = fmt.Fprintf(w, b.String()+"\n"); err != nil {
+			if _, err = fmt.Fprintln(w, b.String()); err != nil {
 				return err
 			}
 		} else if quiet {

--- a/pkg/cmd/volume/list.go
+++ b/pkg/cmd/volume/list.go
@@ -134,7 +134,7 @@ func lsPrintOutput(vols map[string]native.Volume, options types.VolumeListOption
 			if err := tmpl.Execute(&b, p); err != nil {
 				return err
 			}
-			if _, err := fmt.Fprintf(w, b.String()+"\n"); err != nil {
+			if _, err := fmt.Fprintln(w, b.String()); err != nil {
 				return err
 			}
 		} else if options.Quiet {

--- a/pkg/formatter/common.go
+++ b/pkg/formatter/common.go
@@ -65,7 +65,7 @@ func FormatSlice(format string, writer io.Writer, x []interface{}) error {
 					}
 				}
 			}
-			if _, err = fmt.Fprintf(writer, b.String()+"\n"); err != nil {
+			if _, err = fmt.Fprintln(writer, b.String()); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
In quite a few places, we take the pattern of

  b := <template.Execute() output>
  fmt.Printf(..., b.String() + "\n")

This means we end up passing arbitrary strings as a printf-style formatting string, leading to issues whenever there is a literal `%` in the output.  As in #2209, convert to fmt.Fprintln() as appropriate so that we emit the rendered template as-is.